### PR TITLE
🐛 fix calculation for Pi-hole's block-rate

### DIFF
--- a/pihole/piholeBlockratePerClient.sh
+++ b/pihole/piholeBlockratePerClient.sh
@@ -35,7 +35,11 @@ sql="SELECT \
  client AS ip, client_by_id.name AS clientname,
  SUM(count) FILTER (WHERE flag = 'B') AS blocked,
  SUM(count) FILTER (WHERE flag = 'A') AS allowed,
- ((SUM(count) FILTER (WHERE flag = 'B')*100)/SUM(count) FILTER (WHERE flag = 'A')) AS rate
+ CEILING(
+ (SUM(count) FILTER (WHERE flag = 'B')*100)
+ /
+ (SUM(count) FILTER (WHERE flag = 'A')+SUM(count) FILTER (WHERE flag = 'B'))
+ ) AS rate
 FROM
 (
  SELECT * FROM


### PR DESCRIPTION
This PR fixes an issue where rate was miscalculated because it didn't honor **all** requests:  
"rate" must be: "blocked/(allowed+blocked)" and not "blocked/allowed". "rate" will always be the smallest integer value that is greater than or equal to the result of this calculation:

I did verify this with some kind of spreadsheet:

<img width="392" alt="grafik" src="https://user-images.githubusercontent.com/18568381/213925243-f7b3695f-7170-4ce6-a4fd-26a66c124380.png">

