### PR TITLE
🐛 fix path for GH action

### DIFF
--- a/.github/workflow/shellcheck.yml
+++ b/.github/workflow/shellcheck.yml
@@ -5,7 +5,7 @@ on:
     paths:
       # Run workflow on every push
       # only if a file within the specified paths has been changed:
-      - '*.sh'
+      - '**/*.sh'
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
Because shellcheck would have only run if script(s) in root path of repo, but not in sub-dir(s), were updated.