### PR TITLE
🐛 Final fix for gh actions

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Run Shellcheck
         run: |
           set +e
-          find  . -type f | while read -r sh; do
+          find  . -type f | grep -v "\.git" | while read -r sh; do
             if [ "$(file --brief --mime-type "$sh")" == 'text/x-shellscript' ]; then
               echo "shellcheck'ing $sh"
               if ! shellcheck-stable/shellcheck --color=always --severity=warning --exclude=SC1091,SC1090 "$sh"; then


### PR DESCRIPTION
Sorry, I had overseen that the directory for GH actions must be "workflows" and not "workflow"… You may want to have a look in my [GH actions](https://github.com/thomasmerz/fork-hagezi-files/actions) for this PR:

<img width="868" alt="grafik" src="https://user-images.githubusercontent.com/18568381/213933172-8389a587-584c-48b4-961d-56b9df1ad29b.png">

1st run was also checking some stuff in ".git" directory 😞 
So I had to exclude this and 2nd run is fine now 😄 