### PR TITLE
🚸 show real percentage for RATE and not rounded up value

### DIFF
--- a/pihole/piholeBlockratePerClient.sh
+++ b/pihole/piholeBlockratePerClient.sh
@@ -45,11 +45,11 @@ sql="SELECT \
  client AS ip, client_by_id.name AS clientname,
  SUM(count) FILTER (WHERE flag = 'B') AS blocked,
  SUM(count) FILTER (WHERE flag = 'A') AS allowed,
- CEILING(
- (SUM(count) FILTER (WHERE flag = 'B')*100)
+ ROUND(
+ (1.0 * SUM(count) FILTER (WHERE flag = 'B') * 100)
  /
- (SUM(count) FILTER (WHERE flag = 'A')+SUM(count) FILTER (WHERE flag = 'B'))
- ) AS rate
+ (1.0 * SUM(count) FILTER (WHERE flag = 'A') + 1.0 * SUM(count) FILTER (WHERE flag = 'B'))
+ ,2) AS rate
 FROM
 (
  SELECT * FROM


### PR DESCRIPTION
This gives real percentage for RATE as shown here:
```
192.168.42.182                  3406     11354    23.08
192.168.42.237                  101574   313399   24.48
192.168.42.167                  600      1818     24.81
192.168.42.194                  19244    58212    24.85
192.168.42.144                  169958   466324   26.71
192.168.42.229                  33       86       27.73
192.168.42.162                  46       116      28.4
192.168.42.164                  108884   274136   28.43
192.168.42.146                  64898    158700   29.02
192.168.42.117                  73927    176992   29.46
192.168.42.149                  1322     3084     30.0
192.168.42.247                  3456     7948     30.31
192.168.42.197                  628      1422     30.63
192.168.42.218                  8        16       33.33
192.168.42.217                  112558   187681   37.49
192.168.42.105                  209676   347042   37.66
192.168.42.201                  1180     1806     39.52
192.168.42.158                  68       26       72.34
```