### PR TITLE
🚸 show only clients that have at least 100 allowed and 100 blocked queries to reduce some 'noise'

### DIFF
--- a/pihole/piholeBlockratePerClient.sh
+++ b/pihole/piholeBlockratePerClient.sh
@@ -45,11 +45,11 @@ sql="SELECT \
  client AS ip, client_by_id.name AS clientname,
  SUM(count) FILTER (WHERE flag = 'B') AS blocked,
  SUM(count) FILTER (WHERE flag = 'A') AS allowed,
- CEILING(
- (SUM(count) FILTER (WHERE flag = 'B')*100)
+ ROUND(
+ (1.0 * SUM(count) FILTER (WHERE flag = 'B') * 100)
  /
- (SUM(count) FILTER (WHERE flag = 'A')+SUM(count) FILTER (WHERE flag = 'B'))
- ) AS rate
+ (1.0 * SUM(count) FILTER (WHERE flag = 'A') + 1.0 * SUM(count) FILTER (WHERE flag = 'B'))
+ ,2) AS rate
 FROM
 (
  SELECT * FROM

--- a/pihole/piholeBlockratePerClient.sh
+++ b/pihole/piholeBlockratePerClient.sh
@@ -54,9 +54,11 @@ FROM
 (
  SELECT * FROM
  (
-  SELECT client, count(id) as count, 'B' as flag FROM queries WHERE type IN (1,2) AND status IN(1,4,5,6,7,8,9,10,11) GROUP BY client \
+  SELECT client, count(id) as count, 'B' as flag FROM queries WHERE type IN (1,2) AND status IN(1,4,5,6,7,8,9,10,11) GROUP BY client
+    HAVING COUNT(*) > 100
   UNION ALL
-  SELECT client, count(id) as count, 'A' as flag FROM queries WHERE type IN (1,2) AND status IN(2,3,14) GROUP BY client \
+  SELECT client, count(id) as count, 'A' as flag FROM queries WHERE type IN (1,2) AND status IN(2,3,14) GROUP BY client
+    HAVING COUNT(*) > 100
  )
 )
 JOIN client_by_id on client = client_by_id.ip


### PR DESCRIPTION
In my case the reduces the number of ips/clients from 132 to 46. So it hides some ips/clients with low query counts (normal count for regular used devices varies from 16k to 648k with an absolut top-scorer of 1.7m - which is my docker-br-5dcacaf2848e_pihole 😜 ) such as guests or other seldom used gadgets.