### PR TITLE
👷 use current version for checkout for GH action for shellcheck

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       # Required to access files of this repository
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       # Download Shellcheck and add it to the workflow path
       - name: Download Shellcheck


### PR DESCRIPTION
Stay uptodate with https://github.com/actions/checkout/releases